### PR TITLE
一个更好的注解使用的建议

### DIFF
--- a/src/main/java/com/jverson/springboot/demos/MailSenderService.java
+++ b/src/main/java/com/jverson/springboot/demos/MailSenderService.java
@@ -16,7 +16,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 
 import freemarker.template.Configuration;
@@ -25,7 +25,7 @@ import freemarker.template.TemplateException;
 
 
 
-@Component
+@Service
 public class MailSenderService {
 
 	private final Logger logger =  LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
您好，我发现您的代码中的注释可能有一些小的改进。

服务层中的 Spring bean 应该使用 @service 而不是 @component 注解进行注解。
@service注解是@component在服务层的特化。 通过使用专门的注解，可以得到更优的效果。 首先，它们被视为 Spring bean，其次，您可以放置该层所需的特殊行为。

为了更好地理解和维护大型应用程序，@service 是更好的选择。